### PR TITLE
remove d metaphone search from area query

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -6,7 +6,7 @@ class Institution < ApplicationRecord
   include PgSearch::Model
 
   pg_search_scope :search_by_name, against: :name, using: :dmetaphone
-  pg_search_scope :search_by_area, against: %i[county municipality town], using: :dmetaphone
+  pg_search_scope :search_by_area, against: %i[county municipality town]
   pg_search_scope :search_by_class_profiles, against: :class_profiles, using: {tsearch: {any_word: true} }
   pg_search_scope :search_by_sports, against: :sports, using: {tsearch: {any_word: true} }
   pg_search_scope :search_by_foreign_languages, against: :foreign_languages, using: {tsearch: {any_word: true} }


### PR DESCRIPTION
Using d metaphone searching algorithm in area query resulted in weird behavior where search for "Gdynia" returned results from Gdynia and Kutno. (I don't know how these two can sound alike). 